### PR TITLE
Fix removed @*INC

### DIFF
--- a/bin/totem
+++ b/bin/totem
@@ -1,11 +1,7 @@
 #!/usr/bin/env perl6
 use v6;
 
-BEGIN {
-	# The local lib takes priority for now
-	@*INC.unshift('./lib'); 
-}
-
+use lib 'lib';
 use Totem;
 
 sub MAIN(Str :$host = '', Int :$port = 3030) {

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -1,7 +1,5 @@
 use v6;
-
-BEGIN { @*INC.push('lib') };
-
+use lib 'lib';
 use Test;
 
 plan 1;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.
